### PR TITLE
Correct the documentation for the `--without-cython` install option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Ideally, within a virtual environment.
 Changelog
 =========
 
+### 2.4.9 - TBD
+- Corrected the documentation for the `--without-cython` install option
+
 ### 2.4.8 - April 7, 2019
 - Fixed issue #762 - HTTP errors crash with selectable output types
 - Fixed MacOS testing via travis - added testing accross all the same Python versions tested on Linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ or `pip install -r requirements/build.txt`.
 
 Install Hug itself with `pip install .` or `pip install -e .` (for editable mode).
 This will compile all modules with [Cython](https://cython.org/) if it's installed in the environment.
-You can skip Cython compilation using `pip install --without-cython .` (this works with `-e` as well).
+You can skip Cython compilation using `pip install --install-option=--without-cython .` (this works with `-e` as well).
 
 Making a contribution
 =========


### PR DESCRIPTION
With `pip`, a plain `--without-cython` won't work. Instead, `--install-option=--without-cython` is needed.