### PR TITLE
Invoke development runner with Python module

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -46,6 +46,7 @@ Code Contributors
 - Elijah Wilson (@tizz98)
 - Chelsea Dole (@chelseadole)
 - Antti Kaihola (@akaihola)
+- Christopher Goes (@GhostOfGoes)
 
 Documenters
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 =========
 
 ### 2.4.9 - TBD
+- Add the ability to invoke the hug development server as a Python module e.g. `python -m hug`
 - Corrected the documentation for the `--without-cython` install option
 
 ### 2.4.8 - April 7, 2019

--- a/hug/__main__.py
+++ b/hug/__main__.py
@@ -1,0 +1,3 @@
+import hug
+
+hug.development_runner.hug.interface.cli()


### PR DESCRIPTION
Add the ability to invoke the hug development server as a Python module e.g. `python -m hug`.

This was something I meant to do a while back but didn't get around to, finally getting to it now that an issue has been opened about it.

Closes issue #770