### PR TITLE
Support type checking for handler parameters by providing input transformations in decorator argument

### DIFF
--- a/hug/routing.py
+++ b/hug/routing.py
@@ -42,7 +42,8 @@ class Router(object):
     """The base chainable router object"""
     __slots__ = ('route', )
 
-    def __init__(self, transform=None, output=None, validate=None, api=None, requires=(), map_params=None, **kwargs):
+    def __init__(self, transform=None, output=None, validate=None, api=None, requires=(), map_params=None,
+                 args=None, **kwargs):
         self.route = {}
         if transform is not None:
             self.route['transform'] = transform
@@ -56,6 +57,8 @@ class Router(object):
             self.route['requires'] = (requires, ) if not isinstance(requires, (tuple, list)) else requires
         if map_params:
             self.route['map_params'] = map_params
+        if args:
+            self.route['args'] = args
 
     def output(self, formatter, **overrides):
         """Sets the output formatter that should be used to render this route"""


### PR DESCRIPTION
### Problem
Some hug's type annotations (marshmallow fields and schemas in particular) are incompatible with the format of type annotations expected by type checkers such as mypy. For example, the following code
```
from marshmallow import fields


@hug.get('/hello')
def hello(foo: fields.Integer()):
    return "hello"
```
will cause mypy to emit errors that look like this
```
app.py:6: error: Invalid type comment or annotation
app.py:6: note: Suggestion: use fields.Integer[...] instead of fields.Integer(...)
```
As the error message suggests, mypy is not able to recognize object instantiation as proper type annotation. But even if even it could, the type for `foo` variable would still be problematic, as the actual value passed to the handler would actually have type `int`, not `fields.Integer`.

### Solution
There are several possible solutions for this problem:

- Write mypy plugin that overrides marshmallow types and passes correct types to mypy instead. This won't work as the error above happens before mypy plugin has any chance to override the parameter type.
- Wrap hug types in some class and use it in type annotations. Retrieve parameter types from the wrapper class and pass them to mypy via mypy plugin. This might work but it's cumbersome and forces the user to write custom class for each parameter.
- Ignore type annotations in hug handlers altogether by adding `type: ignore` comment next to each of the parameters. This is the only viable solution at the moment (see [this issue](https://github.com/hugapi/hug/issues/554) for example).

Instead I propose the following simple idea: pass transformers as a separate argument to the routing decorator and use type annotations in the handler as usual.
```
from marshmallow import Schema, fields


class TestSchema(Schema):
    bar = fields.String()

@hug.get('/hello', args={
    'foo': fields.Integer(),
    'return': TestSchema()
})
def hello(foo: int) -> dict:
    return {'bar': str(foo)}
```
Here parameters are passed in `args` argument to the route decorator, and the transformation for the data returned from handler can also be specified as a 'return' parameter. If the `args` parameter is present, then the transformations defined in annotations will be ignored (as it is expected that there should be type annotations for type checking purposes), otherwise everything works as before.