### PR TITLE
Support both marshmallow 2 and marshmallow 3 simultaneously

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,6 @@ matrix:
     sudo: required
     python: pypy3.5-6.0
     env: TOXENV=pypy3-marshmallow2
-  - os: osx
-    language: generic
-    env: TOXENV=py35-marshmallow2
-  - os: osx
-    language: generic
-    env: TOXENV=py36-marshmallow2
-  - os: osx
-    language: generic
-    env: TOXENV=py37-marshmallow2
   - os: linux
     sudo: required
     python: 3.7
@@ -36,13 +27,10 @@ matrix:
     env: TOXENV=pypy3-marshmallow3
   - os: osx
     language: generic
-    env: TOXENV=py35-marshmallow3
+    env: TOXENV=py36-marshmallow2
   - os: osx
     language: generic
     env: TOXENV=py36-marshmallow3
-  - os: osx
-    language: generic
-    env: TOXENV=py37-marshmallow3
 before_install:
 - "./scripts/before_install.sh"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,20 @@ matrix:
   - os: linux
     sudo: required
     python: 3.7
-    env: TOXENV=py37
+    env: TOXENV=py37-marshmallow2
   - os: linux
     sudo: required
     python: pypy3.5-6.0
-    env: TOXENV=pypy3
+    env: TOXENV=pypy3-marshmallow2
   - os: osx
     language: generic
-    env: TOXENV=py35
+    env: TOXENV=py35-marshmallow2
   - os: osx
     language: generic
-    env: TOXENV=py36
+    env: TOXENV=py36-marshmallow2
   - os: osx
     language: generic
-    env: TOXENV=py37
+    env: TOXENV=py37-marshmallow2
 before_install:
 - "./scripts/before_install.sh"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,23 @@ matrix:
   - os: osx
     language: generic
     env: TOXENV=py37-marshmallow2
+  - os: linux
+    sudo: required
+    python: 3.7
+    env: TOXENV=py37-marshmallow2
+  - os: linux
+    sudo: required
+    python: pypy3.5-6.0
+    env: TOXENV=pypy3-marshmallow3
+  - os: osx
+    language: generic
+    env: TOXENV=py35-marshmallow3
+  - os: osx
+    language: generic
+    env: TOXENV=py36-marshmallow3
+  - os: osx
+    language: generic
+    env: TOXENV=py37-marshmallow3
 before_install:
 - "./scripts/before_install.sh"
 install:

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,11 +1,2 @@
--r common.txt
-flake8==3.3.0
-isort==4.2.5
+-r build_common.txt
 marshmallow==2.18.1
-pytest-cov==2.4.0
-pytest==4.3.1
-python-coveralls==2.9.0
-wheel==0.29.0
-PyJWT==1.4.2
-pytest-xdist==1.14.0
-numpy==1.15.4

--- a/requirements/build_common.txt
+++ b/requirements/build_common.txt
@@ -1,0 +1,10 @@
+-r common.txt
+flake8==3.3.0
+isort==4.2.5
+pytest-cov==2.4.0
+pytest==4.3.1
+python-coveralls==2.9.0
+wheel==0.29.0
+PyJWT==1.4.2
+pytest-xdist==1.14.0
+numpy==1.15.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist=py{34,35,36,37,py3}, cython
+envlist=py{34,35,36,37,py3}-marshmallow{2,3}, cython-marshmallow{2,3}
 
 [testenv]
-deps=-rrequirements/build.txt
+deps=
+    -rrequirements/build_common.txt
+    marshmallow2: marshmallow <3.0
+    marshmallow3: marshmallow >=3.0.0rc5
+
 whitelist_externals=flake8
 commands=flake8 hug
     py.test --cov-report html --cov hug -n auto tests


### PR DESCRIPTION
Fixes issue #768.

There are several other options to add support for marshmallow 3:

- Support marshmallow 3 in the next major release and drop support for marshmallow 2 there.
- Create two versions of hug package for each release with support for marshmallow 2 or 3 respectively.

Both of these alternatives do not seem reasonable as they are too cumbersome and inconvenient, given that hug depends very little on marshmallow functionality and marshmallow isn't even a requirement for hug package.

The solution proposed in this PR looks a bit ugly, but it allows hug to operate with both marshmallow versions seamlessly by determining the version of marshmallow actually installed in user's environment.

### Concerns
- Are `MarshmallowInputSchema` and `MarshmallowReturnSchema` the only pieces of code that implicitly rely on marshmallow functionality?
- Marshmallow 3 [will only support Python 3.5+](https://marshmallow.readthedocs.io/en/3.0/upgrading.html). Hug currently supports Python 3.4 and I'm not sure what the correct decision here should be - as marshmallow is not in hug dependencies, should the users decide themselves what version of marshmallow should they use and risk having conflicting setup with Python 3.4 and marshmallow 3, or should this functionality wait until hug drops Python 3.4 support. It seems to me that to put marshmallow 3 in their project's dependencies, users themselves should understand that if they have Python 3.4, they shouldn't attempt to install marshmallow 3.