### PR TITLE
fix #794

### DIFF
--- a/hug/types.py
+++ b/hug/types.py
@@ -35,7 +35,9 @@ try:
     import marshmallow
     from marshmallow import ValidationError
 
-    MARSHMALLOW_MAJOR_VERSION = getattr(marshmallow,'__version_info__',LooseVersion(marshmallow.__version__).version)[0]
+    MARSHMALLOW_MAJOR_VERSION = getattr(
+        marshmallow, "__version_info__", LooseVersion(marshmallow.__version__).version
+    )[0]
 except ImportError:
     # Just define the error that is never raised so that Python does not complain.
     class ValidationError(Exception):

--- a/hug/types.py
+++ b/hug/types.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import uuid as native_uuid
 from decimal import Decimal
+from distutils.version import LooseVersion
 
 import hug._empty as empty
 from hug import introspect
@@ -34,7 +35,7 @@ try:
     import marshmallow
     from marshmallow import ValidationError
 
-    MARSHMALLOW_MAJOR_VERSION = marshmallow.__version_info__[0]
+    MARSHMALLOW_MAJOR_VERSION = getattr(marshmallow,'__version_info__',LooseVersion(marshmallow.__version__).version)[0]
 except ImportError:
     # Just define the error that is never raised so that Python does not complain.
     class ValidationError(Exception):


### PR DESCRIPTION
fix the issue that when a marshmallow old version (below 2.17.0) installed, an unexpected AttributeError raised cause there is no __version_info__ attribute in **__init__.py**.