### PR TITLE
corrected marshmallow example to use the correct date format

### DIFF
--- a/documentation/TYPE_ANNOTATIONS.md
+++ b/documentation/TYPE_ANNOTATIONS.md
@@ -92,7 +92,7 @@ Here is a simple example of an API that does datetime addition.
 
 
     @hug.get('/dateadd', examples="value=1973-04-10&addend=63")
-    def dateadd(value: fields.DateTime(),
+    def dateadd(value: fields.Date(),
                 addend: fields.Int(validate=Range(min=1))):
         """Add a value to a date."""
         delta = dt.timedelta(days=addend)


### PR DESCRIPTION
If the "Marshmallow integration" example at the bottom of [type_annotation](http://www.hug.rest/website/learn/type_annotation) page is run as stated it will return:

`{"errors": {"value": "Not a valid datetime."}}`

Either `DateTime` needs to be swapped for `Date` or the example switched from `examples="value=1973-04-10&addend=63"` to `examples="value=2014-12-22T03:12:58.0190770&addend=63"`.