### PR TITLE
Fix development runner `TypeError` when executing cli commands

### DIFF
--- a/hug/development_runner.py
+++ b/hug/development_runner.py
@@ -77,7 +77,7 @@ def hug(
             sys.exit(1)
 
         use_cli_router = slice(
-            start=(sys.argv.index("-c") if "-c" in sys.argv else sys.argv.index("--command")) + 2
+            sys.argv.index("-c") if "-c" in sys.argv else sys.argv.index("--command") + 2
         )
         sys.argv[1:] = sys.argv[use_cli_router]
         api.cli.commands[command]()


### PR DESCRIPTION
Fix `TypeError: slice() takes no keyword arguments`
when executing `hug -f ... -c ...`