### PR TITLE
isort as part of the CI pipeline

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,4 +3,4 @@ multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
-line_length=88
+line_length=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
     env: TOXENV=py37-vulture
   - os: linux
     sudo: required
+    python: 3.7
+    env: TOXENV=py37-isort
+  - os: linux
+    sudo: required
     python: pypy3.5-6.0
     env: TOXENV=pypy3-marshmallow3
   - os: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Ideally, within a virtual environment.
 
 Changelog
 =========
+### 3.0.0 - TBD
+- Added automated code cleaning and linting satisfying [HOPE-8 -- Style Guideline for Hug](https://github.com/hugapi/HOPE/blob/master/all/HOPE-8--Style-Guide-for-Hug-Code.md#hope-8----style-guide-for-hug-code)
+- Implemented [HOPE-20 -- The Zen of Hug](https://github.com/hugapi/HOPE/blob/master/all/HOPE-20--The-Zen-of-Hug.md)
+
 ### 2.5.4 hotfix - May 19, 2019
 - Fix issue #798 - Development runner `TypeError` when executing cli
 

--- a/hug/__init__.py
+++ b/hug/__init__.py
@@ -34,7 +34,6 @@ from __future__ import absolute_import
 from falcon import *
 
 from hug import (
-    defaults,
     directives,
     exceptions,
     format,
@@ -90,7 +89,7 @@ from hug.route import (
 from hug.types import create as type
 
 # The following imports must be imported last; in particular, defaults to have access to all modules
-from hug import authentication  #isort:skip
+from hug import authentication  # isort:skip
 from hug import development_runner  # isort:skip
 from hug import defaults  # isort:skip
 

--- a/hug/__init__.py
+++ b/hug/__init__.py
@@ -33,18 +33,65 @@ from __future__ import absolute_import
 
 from falcon import *
 
-from hug import (defaults, directives, exceptions, format, input_format, introspect, middleware,
-                 output_format, redirect, route, test, transform, types, use, validate)
+from hug import (
+    defaults,
+    directives,
+    exceptions,
+    format,
+    input_format,
+    introspect,
+    middleware,
+    output_format,
+    redirect,
+    route,
+    test,
+    transform,
+    types,
+    use,
+    validate,
+)
 from hug._version import current
 from hug.api import API
-from hug.decorators import (context_factory, default_input_format, default_output_format,
-                            delete_context, directive, extend_api, middleware_class, reqresp_middleware,
-                            request_middleware, response_middleware, startup, wraps)
-from hug.route import (call, cli, connect, delete, exception, get, get_post, head, http, local,
-                       not_found, object, options, patch, post, put, sink, static, trace)
+from hug.decorators import (
+    context_factory,
+    default_input_format,
+    default_output_format,
+    delete_context,
+    directive,
+    extend_api,
+    middleware_class,
+    reqresp_middleware,
+    request_middleware,
+    response_middleware,
+    startup,
+    wraps,
+)
+from hug.route import (
+    call,
+    cli,
+    connect,
+    delete,
+    exception,
+    get,
+    get_post,
+    head,
+    http,
+    local,
+    not_found,
+    object,
+    options,
+    patch,
+    post,
+    put,
+    sink,
+    static,
+    trace,
+)
 from hug.types import create as type
 
-from hug import authentication  # isort:skip - must be imported last for defaults to have access to all modules
+from hug import (
+    authentication,
+)  # isort:skip - must be imported last for defaults to have access to all modules
 
 from hug import development_runner  # isort:skip
 

--- a/hug/__init__.py
+++ b/hug/__init__.py
@@ -33,23 +33,6 @@ from __future__ import absolute_import
 
 from falcon import *
 
-from hug import (
-    authentication,
-    directives,
-    exceptions,
-    format,
-    input_format,
-    introspect,
-    middleware,
-    output_format,
-    redirect,
-    route,
-    test,
-    transform,
-    types,
-    use,
-    validate,
-)
 from hug._version import current
 from hug.api import API
 from hug.decorators import (
@@ -89,10 +72,26 @@ from hug.route import (
 )
 from hug.types import create as type
 
-from hug import development_runner  # isort:skip
 from hug import (
+    authentication,  # isort:skip - must be imported last for defaults to have access to all modules
     defaults,
-)  # isort:skip - must be imported last for defaults to have access to all modules
+    directives,
+    exceptions,
+    format,
+    input_format,
+    introspect,
+    middleware,
+    output_format,
+    redirect,
+    route,
+    test,
+    transform,
+    types,
+    use,
+    validate,
+)
+
+from hug import development_runner  # isort:skip
 
 try:  # pragma: no cover - defaulting to uvloop if it is installed
     import uvloop

--- a/hug/__init__.py
+++ b/hug/__init__.py
@@ -33,63 +33,17 @@ from __future__ import absolute_import
 
 from falcon import *
 
+from hug import authentication  # isort:skip - must be imported last for defaults to have access to all modules
+from hug import (defaults, directives, exceptions, format, input_format, introspect, middleware,
+                 output_format, redirect, route, test, transform, types, use, validate)
 from hug._version import current
 from hug.api import API
-from hug.decorators import (
-    context_factory,
-    default_input_format,
-    default_output_format,
-    delete_context,
-    directive,
-    extend_api,
-    middleware_class,
-    reqresp_middleware,
-    request_middleware,
-    response_middleware,
-    startup,
-    wraps,
-)
-from hug.route import (
-    call,
-    cli,
-    connect,
-    delete,
-    exception,
-    get,
-    get_post,
-    head,
-    http,
-    local,
-    not_found,
-    object,
-    options,
-    patch,
-    post,
-    put,
-    sink,
-    static,
-    trace,
-)
+from hug.decorators import (context_factory, default_input_format, default_output_format,
+                            delete_context, directive, extend_api, middleware_class, reqresp_middleware,
+                            request_middleware, response_middleware, startup, wraps)
+from hug.route import (call, cli, connect, delete, exception, get, get_post, head, http, local,
+                       not_found, object, options, patch, post, put, sink, static, trace)
 from hug.types import create as type
-
-from hug import (
-    authentication,  # isort:skip - must be imported last for defaults to have access to all modules
-    defaults,
-    directives,
-    exceptions,
-    format,
-    input_format,
-    introspect,
-    middleware,
-    output_format,
-    redirect,
-    route,
-    test,
-    transform,
-    types,
-    use,
-    validate,
-)
 
 from hug import development_runner  # isort:skip
 

--- a/hug/__init__.py
+++ b/hug/__init__.py
@@ -33,7 +33,6 @@ from __future__ import absolute_import
 
 from falcon import *
 
-from hug import authentication  # isort:skip - must be imported last for defaults to have access to all modules
 from hug import (defaults, directives, exceptions, format, input_format, introspect, middleware,
                  output_format, redirect, route, test, transform, types, use, validate)
 from hug._version import current
@@ -44,6 +43,8 @@ from hug.decorators import (context_factory, default_input_format, default_outpu
 from hug.route import (call, cli, connect, delete, exception, get, get_post, head, http, local,
                        not_found, object, options, patch, post, put, sink, static, trace)
 from hug.types import create as type
+
+from hug import authentication  # isort:skip - must be imported last for defaults to have access to all modules
 
 from hug import development_runner  # isort:skip
 

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -38,7 +38,15 @@ import hug.types as types
 from hug import introspect
 from hug.exceptions import InvalidTypeData
 from hug.format import parse_content_type
-from hug.types import MarshmallowInputSchema, MarshmallowReturnSchema, Multiple, OneOf, SmartBoolean, Text, text
+from hug.types import (
+    MarshmallowInputSchema,
+    MarshmallowReturnSchema,
+    Multiple,
+    OneOf,
+    SmartBoolean,
+    Text,
+    text,
+)
 
 
 def asyncio_call(function, *args, **kwargs):

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -38,15 +38,7 @@ import hug.types as types
 from hug import introspect
 from hug.exceptions import InvalidTypeData
 from hug.format import parse_content_type
-from hug.types import (
-    MarshmallowInputSchema,
-    MarshmallowReturnSchema,
-    Multiple,
-    OneOf,
-    SmartBoolean,
-    Text,
-    text,
-)
+from hug.types import MarshmallowInputSchema, MarshmallowReturnSchema, Multiple, OneOf, SmartBoolean, Text, text
 
 
 def asyncio_call(function, *args, **kwargs):

--- a/requirements/build_common.txt
+++ b/requirements/build_common.txt
@@ -1,6 +1,5 @@
 -r common.txt
 flake8==3.3.0
-isort==4.2.5
 pytest-cov==2.4.0
 pytest==4.3.1
 python-coveralls==2.9.0

--- a/requirements/build_style_tools.txt
+++ b/requirements/build_style_tools.txt
@@ -1,5 +1,6 @@
 -r build_common.txt
 black==19.3b0
+isort==4.3.20
 pep8-naming==0.8.2
 flake8-bugbear==19.3.0
 vulture==1.0

--- a/tests/test_full_request.py
+++ b/tests/test_full_request.py
@@ -39,11 +39,13 @@ def post(body, response):
 """
 
 
-@pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="Can't run hug CLI from travis PyPy")
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy", reason="Can't run hug CLI from travis PyPy"
+)
 def test_hug_post(tmp_path):
-    hug_test_file = (tmp_path / "hug_postable.py")
+    hug_test_file = tmp_path / "hug_postable.py"
     hug_test_file.write_text(TEST_HUG_API)
-    hug_server = Popen(['hug', '-f', str(hug_test_file), '-p', '3000'])
+    hug_server = Popen(["hug", "-f", str(hug_test_file), "-p", "3000"])
     time.sleep(5)
-    requests.post('http://127.0.0.1:3000/test', {'data': 'here'})
+    requests.post("http://127.0.0.1:3000/test", {"data": "here"})
     hug_server.kill()

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,14 @@ deps=
 whitelist_externals=flake8
 commands=bandit -r hug/ -ll
 
+[testenv:py37-isort]
+deps=
+    -rrequirements/build_style_tools.txt
+    marshmallow >=3.0.0rc5
+
+whitelist_externals=flake8
+commands=isort -c hug/*py
+
 [testenv:pywin]
 deps =-rrequirements/build_windows.txt
 basepython = {env:PYTHON:}\python.exe


### PR DESCRIPTION
Opening a dummy PR to get a little feedback re `isort`. The last 3x commits have been little experiment runs against `isort` and `black`.

When I run `isort -c hug/*py` on the latest commit I get the following.
```
ERROR: /Users/jason/python/hug/hug/__init__.py Imports are incorrectly sorted.
ERROR: /Users/jason/python/hug/hug/interface.py Imports are incorrectly sorted.
```

It seems `black` is also in a bit of a tug-of-war with `isort`, but I haven't looked closely enough to really understand it (yet).


