### PR TITLE
Fix: map_params type docstring

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ exclude_lines = def hug
                 sys.stdout.buffer.write
                 class Socket
                 pragma: no cover
+                except ImportError:

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ exclude_lines = def hug
                 class Socket
                 pragma: no cover
                 except ImportError:
+                if MARSHMALLOW_MAJOR_VERSION is None or MARSHMALLOW_MAJOR_VERSION == 2:

--- a/hug/api.py
+++ b/hug/api.py
@@ -348,8 +348,7 @@ class HTTPInterfaceAPI(InterfaceAPI):
         self, request, response, api_version=None, versions=None, not_found=None, **kwargs
     ):
         """Intelligently routes a request to the correct handler based on the version being requested"""
-        if versions is None:
-            versions = {}
+        versions = {} if versions is None else versions
         request_version = self.determine_version(request, api_version)
         if request_version:
             request_version = int(request_version)

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -854,7 +854,7 @@ class HTTP(Interface):
                 if size:
                     response.set_stream(content, size)
                 else:
-                    response.stream = content
+                    response.stream = content  # pragma: no cover
         else:
             response.data = content
 

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -212,6 +212,7 @@ class Interface(object):
                 for name, transform in self.interface.input_transformations.items()
             }
         else:
+            self.map_params = {}
             self.input_transformations = self.interface.input_transformations
 
         if "output" in route:
@@ -417,8 +418,7 @@ class Local(Interface):
                 self.api.delete_context(context, errors=errors)
                 return outputs(errors) if outputs else errors
 
-        if getattr(self, "map_params", None):
-            self._rewrite_params(kwargs)
+        self._rewrite_params(kwargs)
         try:
             result = self.interface(**kwargs)
             if self.transform:
@@ -617,8 +617,7 @@ class CLI(Interface):
                     elif add_options_to:
                         pass_to_function[add_options_to].append(option)
 
-        if getattr(self, "map_params", None):
-            self._rewrite_params(pass_to_function)
+        self._rewrite_params(pass_to_function)
 
         try:
             if args:
@@ -816,8 +815,7 @@ class HTTP(Interface):
             parameters = {
                 key: value for key, value in parameters.items() if key in self.all_parameters
             }
-        if getattr(self, "map_params", None):
-            self._rewrite_params(parameters)
+        self._rewrite_params(parameters)
 
         return self.interface(**parameters)
 

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -324,7 +324,7 @@ class Interface(object):
             inputs = doc.setdefault("inputs", OrderedDict())
             types = self.interface.spec.__annotations__
             for argument in parameters:
-                kind = types.get(argument, text)
+                kind = types.get(self._remap_entry(argument), text)
                 if getattr(kind, "directive", None) is True:
                     continue
 
@@ -340,6 +340,9 @@ class Interface(object):
         for interface_name, internal_name in self.map_params.items():
             if interface_name in params:
                 params[internal_name] = params.pop(interface_name)
+
+    def _remap_entry(self, interface_name):
+        return self.map_params.get(interface_name, interface_name)
 
     @staticmethod
     def cleanup_parameters(parameters, exception=None):

--- a/hug/routing.py
+++ b/hug/routing.py
@@ -317,7 +317,7 @@ class HTTPRouter(InternalValidation):
         response_headers = {}
         if origins:
 
-            @hug.response_middleware(api=self.route.get('api', None))
+            @hug.response_middleware(api=self.route.get("api", None))
             def process_data(request, response, resource):
                 if "ORIGIN" in request.headers:
                     origin = request.headers["ORIGIN"]

--- a/hug/routing.py
+++ b/hug/routing.py
@@ -317,7 +317,7 @@ class HTTPRouter(InternalValidation):
         response_headers = {}
         if origins:
 
-            @hug.response_middleware()
+            @hug.response_middleware(api=self.route.get('api', None))
             def process_data(request, response, resource):
                 if "ORIGIN" in request.headers:
                     origin = request.headers["ORIGIN"]

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1046,7 +1046,6 @@ def test_extending_api_with_http_and_cli():
 
     # But not both
     with pytest.raises(ValueError):
-
         @hug.extend_api(sub_command="sub_api", command_prefix="api_", http=False)
         def extend_with():
             return (tests.module_fake_http_and_cli,)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1576,20 +1576,25 @@ def test_cli_with_multiple_ints():
     assert hug.test.cli(test_multiple_cli, ints=["1", "2", "3"]) == [1, 2, 3]
 
 
-def test_startup():
+def test_startup(hug_api):
     """Test to ensure hug startup decorators work as expected"""
+    happened_on_startup = []
 
-    @hug.startup()
+    @hug.startup(api=hug_api)
     def happens_on_startup(api):
-        pass
+        happened_on_startup.append("non-async")
 
-    @hug.startup()
+    @hug.startup(api=hug_api)
     @asyncio.coroutine
     def async_happens_on_startup(api):
-        pass
+        happened_on_startup.append("async")
 
-    assert happens_on_startup in api.startup_handlers
-    assert async_happens_on_startup in api.startup_handlers
+    assert happens_on_startup in hug_api.startup_handlers
+    assert async_happens_on_startup in hug_api.startup_handlers
+
+    hug_api._ensure_started()
+    assert "async" in happened_on_startup
+    assert "non-async" in happened_on_startup
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Currently failing on Windows build")

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1042,8 +1042,6 @@ def test_extending_api_with_http_and_cli():
     def extend_with():
         return (tests.module_fake_http_and_cli,)
 
-    assert hug.test.cli("sub_api", "made_up_go", api=api)
-
     # But not both
     with pytest.raises(ValueError):
         @hug.extend_api(sub_command="sub_api", command_prefix="api_", http=False)
@@ -1051,7 +1049,7 @@ def test_extending_api_with_http_and_cli():
             return (tests.module_fake_http_and_cli,)
 
 
-def test_extending_api_with_http_and_cli():
+def test_extending_api_with_http_and_cli_sub_module():
     """Test to ensure it's possible to extend the current API so both HTTP and CLI APIs are extended"""
     import tests.module_fake_http_and_cli
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -185,3 +185,11 @@ def test_marshmallow_return_type_documentation():
     doc = api.http.documentation()
 
     assert doc["handlers"]["/marshtest"]["POST"]["outputs"]["type"] == "Return docs"
+
+def test_map_params_documentation_preserves_type():
+    @hug.get(map_params={"from": "from_mapped"})
+    def map_params_test(from_mapped: hug.types.number):
+        pass
+
+    doc = api.http.documentation()
+    assert doc["handlers"]["/map_params_test"]["GET"]["inputs"]["from"]["type"] == "A whole number"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -414,8 +414,8 @@ class TestURLRouter(TestHTTPRouter):
             "google.com", methods=("GET", "POST"), credentials=True, headers="OPTIONS", max_age=10
         )
 
-        @test_headers.get(headers={'ORIGIN': 'google.com'})
+        @test_headers.get()
         def my_endpoint():
             return "Success"
 
-        assert hug.test.get(hug_api, "/my_endpoint").data == "Success"
+        assert hug.test.get(hug_api, "/my_endpoint", headers={'ORIGIN': 'google.com'}).data == "Success"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -406,3 +406,16 @@ class TestURLRouter(TestHTTPRouter):
     def test_suffixes(self):
         """Test to ensure setting suffixes works as expected"""
         assert self.route.suffixes(".js", ".xml").route["suffixes"] == (".js", ".xml")
+
+    def test_allow_origins_request_handling(self, hug_api):
+        """Test to ensure a route with allowed origins works as expected"""
+        route = URLRouter(api=hug_api)
+        test_headers = route.allow_origins(
+            "google.com", methods=("GET", "POST"), credentials=True, headers="OPTIONS", max_age=10
+        )
+
+        @test_headers.get(headers={'ORIGIN': 'google.com'})
+        def my_endpoint():
+            return "Success"
+
+        assert hug.test.get(hug_api, "/my_endpoint").data == "Success"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -320,6 +320,10 @@ def test_json():
     with pytest.raises(ValueError):
         hug.types.json("Invalid JSON")
 
+    assert hug.types.json(json.dumps(["a", "b"]).split(",")) == ["a", "b"]
+    with pytest.raises(ValueError):
+        assert hug.types.json(["Invalid JSON", "Invalid JSON"])
+
 
 def test_multi():
     """Test to ensure that the multi type correctly handles a variety of value types"""

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
     marshmallow3: marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
-commands=py.test --cov-report html --cov hug -n auto tests
+commands=py.test --durations 3 --cov-report html --cov hug -n auto tests
 
 [testenv:py37-black]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py{35,36,37,py3}-marshmallow{2,3}, cython-marshmallow{2,3}
 deps=
     -rrequirements/build_common.txt
     marshmallow2: marshmallow <3.0
-    marshmallow3: marshmallow==3.0.0rc6<3.0.0rc7
+    marshmallow3: marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
 commands=py.test --cov-report html --cov hug -n auto tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py{35,36,37,py3}-marshmallow{2,3}, cython-marshmallow{2,3}
 deps=
     -rrequirements/build_common.txt
     marshmallow2: marshmallow <3.0
-    marshmallow3: marshmallow >=3.0.0rc5<3.0.0rc7<3.0.0rc7
+    marshmallow3: marshmallow==3.0.0rc6<3.0.0rc7
 
 whitelist_externals=flake8
 commands=py.test --cov-report html --cov hug -n auto tests
@@ -13,7 +13,7 @@ commands=py.test --cov-report html --cov hug -n auto tests
 [testenv:py37-black]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5<3.0.0rc7
+    marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
 commands=black --check --verbose -l 100 hug
@@ -21,7 +21,7 @@ commands=black --check --verbose -l 100 hug
 [testenv:py37-vulture]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5<3.0.0rc7
+    marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
 commands=vulture hug --min-confidence 100 --ignore-names req_succeeded
@@ -30,7 +30,7 @@ commands=vulture hug --min-confidence 100 --ignore-names req_succeeded
 [testenv:py37-flake8]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5<3.0.0rc7
+    marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
 commands=flake8 hug
@@ -38,7 +38,7 @@ commands=flake8 hug
 [testenv:py37-bandit]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5<3.0.0rc7
+    marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
 commands=bandit -r hug/ -ll
@@ -46,7 +46,7 @@ commands=bandit -r hug/ -ll
 [testenv:py37-isort]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5<3.0.0rc7
+    marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
 commands=isort -c --diff --recursive hug

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py{35,36,37,py3}-marshmallow{2,3}, cython-marshmallow{2,3}
 deps=
     -rrequirements/build_common.txt
     marshmallow2: marshmallow <3.0
-    marshmallow3: marshmallow >=3.0.0rc5
+    marshmallow3: marshmallow >=3.0.0rc5<3.0.0rc7
 
 whitelist_externals=flake8
 commands=py.test --cov-report html --cov hug -n auto tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py{35,36,37,py3}-marshmallow{2,3}, cython-marshmallow{2,3}
 deps=
     -rrequirements/build_common.txt
     marshmallow2: marshmallow <3.0
-    marshmallow3: marshmallow >=3.0.0rc5<3.0.0rc7
+    marshmallow3: marshmallow >=3.0.0rc5<3.0.0rc7<3.0.0rc7
 
 whitelist_externals=flake8
 commands=py.test --cov-report html --cov hug -n auto tests
@@ -13,7 +13,7 @@ commands=py.test --cov-report html --cov hug -n auto tests
 [testenv:py37-black]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5
+    marshmallow >=3.0.0rc5<3.0.0rc7
 
 whitelist_externals=flake8
 commands=black --check --verbose -l 100 hug
@@ -21,7 +21,7 @@ commands=black --check --verbose -l 100 hug
 [testenv:py37-vulture]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5
+    marshmallow >=3.0.0rc5<3.0.0rc7
 
 whitelist_externals=flake8
 commands=vulture hug --min-confidence 100 --ignore-names req_succeeded
@@ -30,7 +30,7 @@ commands=vulture hug --min-confidence 100 --ignore-names req_succeeded
 [testenv:py37-flake8]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5
+    marshmallow >=3.0.0rc5<3.0.0rc7
 
 whitelist_externals=flake8
 commands=flake8 hug
@@ -38,7 +38,7 @@ commands=flake8 hug
 [testenv:py37-bandit]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5
+    marshmallow >=3.0.0rc5<3.0.0rc7
 
 whitelist_externals=flake8
 commands=bandit -r hug/ -ll
@@ -46,7 +46,7 @@ commands=bandit -r hug/ -ll
 [testenv:py37-isort]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow >=3.0.0rc5
+    marshmallow >=3.0.0rc5<3.0.0rc7
 
 whitelist_externals=flake8
 commands=isort -c --diff --recursive hug


### PR DESCRIPTION
If map_params is used, API documentation reports parameter type always as Basic text.

Added tests to `test_documentation.py` and hopefully fixed it. 

Also refactored constructor a bit so that several `if` conditions can be removed.