### PR TITLE
Fix: map params type docstring

### DIFF
--- a/hug/interface.py
+++ b/hug/interface.py
@@ -212,6 +212,7 @@ class Interface(object):
                 for name, transform in self.interface.input_transformations.items()
             }
         else:
+            self.map_params = {}
             self.input_transformations = self.interface.input_transformations
 
         if "output" in route:
@@ -417,8 +418,7 @@ class Local(Interface):
                 self.api.delete_context(context, errors=errors)
                 return outputs(errors) if outputs else errors
 
-        if getattr(self, "map_params", None):
-            self._rewrite_params(kwargs)
+        self._rewrite_params(kwargs)
         try:
             result = self.interface(**kwargs)
             if self.transform:
@@ -617,8 +617,7 @@ class CLI(Interface):
                     elif add_options_to:
                         pass_to_function[add_options_to].append(option)
 
-        if getattr(self, "map_params", None):
-            self._rewrite_params(pass_to_function)
+        self._rewrite_params(pass_to_function)
 
         try:
             if args:
@@ -816,8 +815,7 @@ class HTTP(Interface):
             parameters = {
                 key: value for key, value in parameters.items() if key in self.all_parameters
             }
-        if getattr(self, "map_params", None):
-            self._rewrite_params(parameters)
+        self._rewrite_params(parameters)
 
         return self.interface(**parameters)
 

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -324,7 +324,7 @@ class Interface(object):
             inputs = doc.setdefault("inputs", OrderedDict())
             types = self.interface.spec.__annotations__
             for argument in parameters:
-                kind = types.get(argument, text)
+                kind = types.get(self._remap_entry(argument), text)
                 if getattr(kind, "directive", None) is True:
                     continue
 
@@ -340,6 +340,9 @@ class Interface(object):
         for interface_name, internal_name in self.map_params.items():
             if interface_name in params:
                 params[internal_name] = params.pop(interface_name)
+
+    def _remap_entry(self, interface_name):
+        return self.map_params.get(interface_name, interface_name)
 
     @staticmethod
     def cleanup_parameters(parameters, exception=None):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -185,3 +185,11 @@ def test_marshmallow_return_type_documentation():
     doc = api.http.documentation()
 
     assert doc["handlers"]["/marshtest"]["POST"]["outputs"]["type"] == "Return docs"
+
+def test_map_params_documentation_preserves_type():
+    @hug.get(map_params={"from": "from_mapped"})
+    def map_params_test(from_mapped: hug.types.number):
+        pass
+
+    doc = api.http.documentation()
+    assert doc["handlers"]["/map_params_test"]["GET"]["inputs"]["from"]["type"] == "A whole number"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps=
     marshmallow3: marshmallow==3.0.0rc6
 
 whitelist_externals=flake8
-commands=py.test --cov-report html --cov hug -n auto tests
+commands=py.test --durations 3 --cov-report html --cov hug -n auto tests
 
 [testenv:py37-black]
 deps=


### PR DESCRIPTION
If `map_params` is used, API documentation reports parameter type always as Basic text.

Added tests to `test_documentation.py` and hopefully fixed it (well, test passes ;))

Also refactored constructor a bit so that several if conditions can be removed.